### PR TITLE
#5 Adiciona restrição de permissões para o recurso Post

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
+
+		<!-- io.jsonwebtoken -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/dev/arielalvesdutra/prs/configs/SecurityConfig.java
+++ b/src/main/java/dev/arielalvesdutra/prs/configs/SecurityConfig.java
@@ -1,19 +1,58 @@
 package dev.arielalvesdutra.prs.configs;
 
+import dev.arielalvesdutra.prs.repositories.UserRepository;
+import dev.arielalvesdutra.prs.services.AuthService;
+import dev.arielalvesdutra.prs.services.TokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-@EnableWebSecurity
+
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private AuthService authService;
+
+    @Override
+    @Bean
+    protected AuthenticationManager authenticationManager() throws Exception {
+        return super.authenticationManager();
+    }
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 .antMatchers("/**").permitAll()
-                .anyRequest().authenticated()
-                .and().csrf().disable();
+                .and().csrf().disable()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterBefore(
+                        new TokenAuthenticationFilter(tokenService, userRepository),
+                        UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(authService)
+                .passwordEncoder(new BCryptPasswordEncoder());
     }
 }

--- a/src/main/java/dev/arielalvesdutra/prs/configs/TokenAuthenticationFilter.java
+++ b/src/main/java/dev/arielalvesdutra/prs/configs/TokenAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package dev.arielalvesdutra.prs.configs;
+
+import dev.arielalvesdutra.prs.entities.User;
+import dev.arielalvesdutra.prs.repositories.UserRepository;
+import dev.arielalvesdutra.prs.services.TokenService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private TokenService tokenService;
+
+    private UserRepository userRepository;
+
+    public TokenAuthenticationFilter(TokenService tokenService, UserRepository userRepository) {
+        this.tokenService = tokenService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = this.retrieveToken(request);
+
+        boolean isValidToken = this.tokenService.isValidToken(token);
+
+        if (isValidToken) {
+            this.authenticateUser(token);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateUser(String token) {
+
+        Long userId = tokenService.getUserId(token);
+        User user = userRepository.findById(userId).get();
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String retrieveToken(HttpServletRequest request) {
+        String token = request.getHeader("Authorization");
+
+        if (!this.isValidRequestTokenHeaderFormat(token)) {
+            return null;
+        }
+
+        return token.substring(7, token.length());
+    }
+
+    private Boolean isValidRequestTokenHeaderFormat(String token) {
+        if (token == null || token.isEmpty() || !token.startsWith("Bearer ")) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/controllers/AuthController.java
+++ b/src/main/java/dev/arielalvesdutra/prs/controllers/AuthController.java
@@ -1,0 +1,39 @@
+package dev.arielalvesdutra.prs.controllers;
+
+import dev.arielalvesdutra.prs.controllers.dto.LoginFormDTO;
+import dev.arielalvesdutra.prs.controllers.dto.TokenDTO;
+import dev.arielalvesdutra.prs.services.TokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+
+    @Autowired
+    private AuthenticationManager authManager;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @PostMapping
+    public ResponseEntity<TokenDTO> auth(@RequestBody @Valid LoginFormDTO formDto)
+            throws AuthenticationException {
+
+        UsernamePasswordAuthenticationToken loginData = formDto.toUsernamePasswordAuthenticationToken();
+        Authentication authentication = authManager.authenticate(loginData);
+        String token = tokenService.generateToken(authentication);
+
+        return ResponseEntity.ok(new TokenDTO(token));
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/controllers/HomeController.java
+++ b/src/main/java/dev/arielalvesdutra/prs/controllers/HomeController.java
@@ -1,0 +1,16 @@
+package dev.arielalvesdutra.prs.controllers;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @RequestMapping(path = "/", method = RequestMethod.GET)
+    public ResponseEntity<String> home() {
+
+        return ResponseEntity.ok().body("Seja bem vindo!");
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/controllers/PostController.java
+++ b/src/main/java/dev/arielalvesdutra/prs/controllers/PostController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -23,6 +24,7 @@ public class PostController {
     @Autowired
     private PostService postService;
 
+    @PreAuthorize("hasAuthority('posts.create')")
     @RequestMapping(method = RequestMethod.POST)
     public ResponseEntity<RetrievePostDTO> create(
             @Valid @RequestBody CreatePostDTO createDto, UriComponentsBuilder uriBuilder) {
@@ -35,6 +37,7 @@ public class PostController {
         return ResponseEntity.created(uri).body(new RetrievePostDTO(createdPost));
     }
 
+    @PreAuthorize("hasAuthority('posts.read')")
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity<Page<RetrievePostDTO>> retrieveAll(
             @PageableDefault(sort="title", page = 0, size = 10) Pageable pagination) {
@@ -44,6 +47,7 @@ public class PostController {
         return ResponseEntity.ok().body(RetrievePostDTO.toPage(postsPage));
     }
 
+    @PreAuthorize("hasAuthority('posts.read')")
     @RequestMapping(method = RequestMethod.GET, path = "/{postId}")
     public ResponseEntity<RetrievePostDTO> retrieveById(@PathVariable Long postId) {
 
@@ -52,6 +56,7 @@ public class PostController {
         return ResponseEntity.ok().body(new RetrievePostDTO(post));
     }
 
+    @PreAuthorize("hasAuthority('posts.delete')")
     @RequestMapping(method = RequestMethod.DELETE, path = "/{postId}")
     public ResponseEntity<?> deleteById(@PathVariable Long postId) {
 
@@ -60,6 +65,7 @@ public class PostController {
         return ResponseEntity.ok().build();
     }
 
+    @PreAuthorize("hasAuthority('posts.update')")
     @RequestMapping(method = RequestMethod.PUT, path = "/{postId}")
     public ResponseEntity<RetrievePostDTO> updateById(
             @PathVariable Long postId,

--- a/src/main/java/dev/arielalvesdutra/prs/controllers/dto/LoginFormDTO.java
+++ b/src/main/java/dev/arielalvesdutra/prs/controllers/dto/LoginFormDTO.java
@@ -1,0 +1,25 @@
+package dev.arielalvesdutra.prs.controllers.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@Getter @Setter @NoArgsConstructor @ToString
+public class LoginFormDTO {
+
+    private String password;
+
+    private String email;
+
+    public LoginFormDTO(String email, String password) {
+        setEmail(email);
+        setPassword(password);
+    }
+
+    public UsernamePasswordAuthenticationToken toUsernamePasswordAuthenticationToken() {
+        return new UsernamePasswordAuthenticationToken(
+                this.getEmail(), this.getPassword());
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/controllers/dto/TokenDTO.java
+++ b/src/main/java/dev/arielalvesdutra/prs/controllers/dto/TokenDTO.java
@@ -1,0 +1,15 @@
+package dev.arielalvesdutra.prs.controllers.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter @NoArgsConstructor
+public class TokenDTO {
+
+    private String token;
+
+    public TokenDTO(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/entities/Permission.java
+++ b/src/main/java/dev/arielalvesdutra/prs/entities/Permission.java
@@ -1,9 +1,6 @@
 package dev.arielalvesdutra.prs.entities;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.Accessors;
 
 import javax.persistence.*;
@@ -14,6 +11,7 @@ import java.util.Set;
 @Entity
 @EqualsAndHashCode(of = "id")
 @ToString
+@NoArgsConstructor
 public class Permission {
 
     @Id
@@ -36,4 +34,8 @@ public class Permission {
     @ManyToMany(mappedBy = "permissions")
     @Getter @Setter @Accessors(chain = true)
     private Set<Role> roles = new HashSet<>();
+
+    public Permission(String name) {
+        setName(name);
+    }
 }

--- a/src/main/java/dev/arielalvesdutra/prs/entities/Role.java
+++ b/src/main/java/dev/arielalvesdutra/prs/entities/Role.java
@@ -32,7 +32,7 @@ public class Role {
     @Getter @Setter @Accessors(chain = true)
     private Instant createdAt = Instant.now();
 
-    @ManyToMany
+    @ManyToMany( fetch = FetchType.EAGER)
     @JoinTable(name = "role_permission",
         joinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"),
         inverseJoinColumns = @JoinColumn(name = "permission_id", referencedColumnName = "id"))

--- a/src/main/java/dev/arielalvesdutra/prs/entities/User.java
+++ b/src/main/java/dev/arielalvesdutra/prs/entities/User.java
@@ -28,7 +28,7 @@ public class User implements UserDetails {
     private String email;
     @Getter @Setter @Accessors(chain = true)
     private String password;
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(name = "user_role",
             joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"),
             inverseJoinColumns = @JoinColumn(name = "role_id", referencedColumnName = "id"))
@@ -75,5 +75,9 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public void addRole(Role role) {
+        this.getRoles().add(role);
     }
 }

--- a/src/main/java/dev/arielalvesdutra/prs/repositories/UserRepository.java
+++ b/src/main/java/dev/arielalvesdutra/prs/repositories/UserRepository.java
@@ -3,4 +3,7 @@ package dev.arielalvesdutra.prs.repositories;
 import dev.arielalvesdutra.prs.entities.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> { }
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    User findByEmail(String email);
+}

--- a/src/main/java/dev/arielalvesdutra/prs/services/AuthService.java
+++ b/src/main/java/dev/arielalvesdutra/prs/services/AuthService.java
@@ -1,0 +1,25 @@
+package dev.arielalvesdutra.prs.services;
+
+import dev.arielalvesdutra.prs.entities.User;
+import dev.arielalvesdutra.prs.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email);
+
+        if (user == null) throw new UsernameNotFoundException("Usuário ou senha inválidos");
+
+        return user;
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/services/TokenService.java
+++ b/src/main/java/dev/arielalvesdutra/prs/services/TokenService.java
@@ -1,0 +1,59 @@
+package dev.arielalvesdutra.prs.services;
+
+import dev.arielalvesdutra.prs.entities.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class TokenService {
+
+    private final Long EXPIRATION = 86400000L;
+
+    private final String SECRET = "K7BdEpBiB8ZQ9hKipojPREG2H3GhNAo3";
+
+    public String generateToken(Authentication authentication) {
+
+        User loggedUser = (User) authentication.getPrincipal();
+
+        return generateToken(loggedUser);
+    }
+
+    public String generateToken(User user) {
+
+        Date today = new Date();
+        Date expirationDate = new Date(today.getTime() + EXPIRATION);
+
+        return Jwts.builder()
+                .setIssuer("Post Register System")
+                .setSubject(user.getId().toString())
+                .setIssuedAt(today)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS256, SECRET)
+                .compact();
+    }
+
+    public boolean isValidToken(String token) {
+
+        try {
+            Jwts.parser().setSigningKey(SECRET).parseClaimsJws(token);
+            return true;
+        } catch (Exception exception) {
+            return false;
+        }
+    }
+
+    public Long getUserId(String token) {
+
+        Claims claims = Jwts.parser().
+                setSigningKey(SECRET)
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+}

--- a/src/main/java/dev/arielalvesdutra/prs/services/UserService.java
+++ b/src/main/java/dev/arielalvesdutra/prs/services/UserService.java
@@ -5,6 +5,7 @@ import dev.arielalvesdutra.prs.entities.User;
 import dev.arielalvesdutra.prs.repositories.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -24,6 +25,10 @@ public class UserService {
     }
 
     public User create(User user) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+
         return userRepository.save(user);
     }
 

--- a/src/test/java/dev/arielalvesdutra/prs/it/controllers/AuthControllerIT.java
+++ b/src/test/java/dev/arielalvesdutra/prs/it/controllers/AuthControllerIT.java
@@ -1,0 +1,66 @@
+package dev.arielalvesdutra.prs.it.controllers;
+
+import dev.arielalvesdutra.prs.builders.UserBuilder;
+import dev.arielalvesdutra.prs.controllers.dto.LoginFormDTO;
+import dev.arielalvesdutra.prs.controllers.dto.TokenDTO;
+import dev.arielalvesdutra.prs.repositories.UserRepository;
+import dev.arielalvesdutra.prs.services.UserService;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@AutoConfigureTestDatabase
+@ActiveProfiles("it")
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class AuthControllerIT {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @After
+    public void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void authentication_withValidUser_shouldWork() {
+        String password = "password";
+        String email = "michal@dundermifflin.com";
+        userService.create(new UserBuilder()
+                .withEmail(email)
+                .withPassword(password)
+                .build());
+        LoginFormDTO loginFormDTO = new LoginFormDTO(email, password);
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<LoginFormDTO> httpEntity = new HttpEntity<>(loginFormDTO, headers);
+
+        ResponseEntity<TokenDTO> response = restTemplate.exchange(
+                "/auth",
+                HttpMethod.POST,
+                httpEntity,
+                TokenDTO.class);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody().getToken()).isNotNull();
+    }
+}

--- a/src/test/java/dev/arielalvesdutra/prs/it/controllers/HomeControllerIT.java
+++ b/src/test/java/dev/arielalvesdutra/prs/it/controllers/HomeControllerIT.java
@@ -1,0 +1,34 @@
+package dev.arielalvesdutra.prs.it.controllers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@RunWith(SpringRunner.class)
+@ActiveProfiles("it")
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class HomeControllerIT {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void rootRoute_shouldReturnWelcomeMessageWith200Status() {
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/",
+                HttpMethod.GET,
+                null, String.class);
+
+        assertThat(response.getStatusCodeValue()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo("Seja bem vindo!");
+    }
+}


### PR DESCRIPTION
- Adiciona restrição de permissão para o recurso Post com as permissões: posts.create, posts.read, posts.delete e posts.update
- Adiciona autenticação via JWT e utilizando usuário do banco de dados
- Adiciona fetch=EAGER em algumas entidades
- Adicionar HomeController
- Ajusta de testes da PostControllerIT para se ajustar a necessidade de usuário autenticado e com permissão